### PR TITLE
feat: install ksm cli on alpine

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,6 +42,23 @@ jobs:
               exit 1
             fi
 
+  integration-test-install-on-alpine:
+    docker:
+      - image: alpine:3.15
+    steps:
+      - keeper/install
+      - run:
+          name: "Assert keeper installation"
+          command: |
+            if [[ -f keeper.ini ]]; then
+              echo "❌ keeper.ini file created in the current directory."
+              exit 1
+            fi      
+            if [[ ! -f /tmp/keeper.ini ]]; then
+              echo "❌ no keeper.ini file created in the /tmp directory."
+              exit 1
+            fi
+
   integration-test-env-export:
     docker:
       - image: cimg/base:stable
@@ -68,6 +85,34 @@ jobs:
               exit 1;
             fi
 
+  integration-test-env-export-on-alpine:
+    docker:
+      - image: alpine:3.15
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://zB_JnULMlYaeCEQPE8p3HA/field/login
+          var-name: MY_USER
+      - keeper/env-export:
+          secret-url: keeper://zB_JnULMlYaeCEQPE8p3HA/field/password
+          var-name: MY_PASSWORD
+      - run:
+          name: "Assert environment variables set"
+          command: |
+            . $BASH_ENV
+            
+            if [[ "$MY_USER" != "test" ]]; then
+              echo "❌ MY_USER env invalid"
+              echo "Expected MY_USER=test, but was MY_USER=${MY_USER}"
+              echo "Content of export command: $(cat $BASH_ENV)"
+              exit 1;
+            fi              
+            if [[ "$MY_PASSWORD" != "keeper2022" ]]; then
+              echo "❌ MY_PASSWORD env invalid"
+              echo "Expected MY_PASSWORD=keeper2022, but was MY_PASSWORD=${MY_USER}"
+              echo "Content of export command: $(cat $BASH_ENV)"
+              exit 1;
+            fi
+
 workflows:
   test-deploy:
     jobs:
@@ -76,7 +121,11 @@ workflows:
           filters: *filters
       - integration-test-install-version:
           filters: *filters
+      - integration-test-install-on-alpine:
+          filters: *filters
       - integration-test-env-export:
+          filters: *filters
+      - integration-test-env-export-on-alpine:
           filters: *filters
       - orb-tools/pack:
           filters: *filters
@@ -88,7 +137,9 @@ workflows:
             - orb-tools/pack
             - integration-test-install-latest
             - integration-test-install-version
+            - integration-test-install-on-alpine
             - integration-test-env-export
+            - integration-test-env-export-on-alpine
           context: keeper-orb-publishing
           filters:
             branches:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -12,7 +12,7 @@ parameters:
     description: "Path to install KSM CLI to"
   shell:
     type: string
-    default: /bin/bash
+    default: /bin/sh
     description: "The shell used to run the install script"
   ini_dir:
     type: string

--- a/src/scripts/env-export/env-export.sh
+++ b/src/scripts/env-export/env-export.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -o errexit  # Exit when simple command fails               'set -e'
-set -o errtrace # Exit on error inside any functions or subshells.
-set -o pipefail # Do not hide errors within pipes              'set -o pipefail'
+#!/bin/sh
+set -e
 
 generate_random_heredoc_identifier() {
   cat /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1
@@ -13,12 +11,12 @@ get_secret_from_ksm() {
 }
 
 EnvExport() {
-  if [ "x${SECRET_ENV_NAME}" == "x" ]; then
+  if [ "x${SECRET_ENV_NAME}" = "x" ]; then
     >&2 echo "SECRET_ENV_NAME env var not set"
     exit 1
   fi
 
-  if [ "x${SECRET_URL}" == "x" ]; then
+  if [ "x${SECRET_URL}" = "x" ]; then
     >&2 echo "SECRET_URL env var not set"
     exit 1
   fi
@@ -40,6 +38,6 @@ EnvExport() {
 
 # Will not run if sourced from another script.
 # This is done so this script may be tested.
-if [ "${0#*$TEST_ENV}" == "$0" ]; then
+if [ "${0#*$TEST_ENV}" = "$0" ]; then
     EnvExport
 fi

--- a/src/scripts/install/init_config.sh
+++ b/src/scripts/install/init_config.sh
@@ -1,14 +1,12 @@
-#!/bin/bash
-set -o errexit  # Exit when simple command fails               'set -e'
-set -o errtrace # Exit on error inside any functions or subshells.
-set -o pipefail # Do not hide errors within pipes              'set -o pipefail'
+#!/bin/sh
+set -e
 
 ksm_init_config(){
   ksm version
 }
 
 InitKeeperConfig() {
-  if [ "x${KEEPER_INI_DIR}" == "x" ]; then
+  if [ "x${KEEPER_INI_DIR}" = "x" ]; then
     >&2 echo "KEEPER_INI_DIR env var not set"
     exit 1
   fi
@@ -21,6 +19,6 @@ InitKeeperConfig() {
 
 # Will not run if sourced from another script.
 # This is done so this script may be tested.
-if [ "${0#*$TEST_ENV}" == "$0" ]; then
+if [ "${0#*$TEST_ENV}" = "$0" ]; then
     InitKeeperConfig
 fi

--- a/src/scripts/install/install_ksm.sh
+++ b/src/scripts/install/install_ksm.sh
@@ -1,52 +1,107 @@
 #!/bin/sh
 set -e
 
-# Colors
-NO_COLOR="\033[0m"
-OK_COLOR="\033[32;01m"
-ERROR_COLOR="\033[31;01m"
+readOsReleaseFile() {
+  cat /etc/os-release 2>/dev/null
+}
 
-# Detect OS
-UNAME=$(uname)
-if [ "$UNAME" = "Linux" ]; then
-    OS=linux
-else
-    echo "${ERROR_COLOR}Cannot determine compatible OS type. Exiting...${NO_COLOR}"
-    exit;
+isAlpine() {
+
+  os_release_id=$(readOsReleaseFile | grep ^ID= | cut -d "=" -f 2)
+  if [ "$os_release_id" = "alpine" ];
+  then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+installKsmAlpine() {
+  echo "➡️ Install KSM on Alpine"
+
+  apk add --update --no-cache curl
+
+  if [ "${KSM_CLI_VERSION:-latest}" != "latest" ]; then
+    VERSION=${KSM_CLI_VERSION}
+  else
+    # Retrieve latest version
+    echo "➡️ Retrieving latest version"
+    VERSION=$(curl --silent "https://api.github.com/repos/Keeper-Security/secrets-manager/releases/latest" | grep tag_name | awk -F\" '{ print $4 }' | awk -F- '{print $3}')
+  fi
+
+  # Exit if version is already installed
+  if command -v ksm >/dev/null 2>&1 && ksm version 2>&1 | grep "CLI Version: " | cut -d " " -f 3 | grep -q "${VERSION}$"; then
+    echo "➡️ Version ${VERSION} is already installed"
+    exit 0
+  fi
+
+
+  apk add --update --no-cache build-base libffi-dev python3 python3-dev py3-wheel && ln -sf python3 /usr/bin/python;
+  python3 -m ensurepip;
+  pip3 install --no-cache --upgrade pip setuptools;
+  pip3 install keeper-secrets-manager-cli=="${VERSION}"
+
+}
+
+installKsmWithBinary() {
+  echo "➡️ Install KSM with binary"
+
+  # Detect OS
+  UNAME=$(uname)
+  if [ "$UNAME" = "Linux" ]; then
+      OS=linux
+  else
+      echo "❌ Cannot determine compatible OS type. Exiting..."
+      exit;
+  fi
+
+  # Make sure we have root priviliges.
+  SUDO=""
+  if [ "$(id -u)" -ne 0 ]; then
+      if ! [ "$(command -v sudo)" ]; then
+          echo "❌ Installer requires root privileges. Please run this script as root."
+          exit;
+      fi
+      SUDO="sudo"
+  fi
+
+  echo "➡️ Creating directories"
+  $SUDO mkdir -p /usr/local/ksm/bin
+
+  if [ "${KSM_CLI_VERSION:-latest}" != "latest" ]; then
+    VERSION=${KSM_CLI_VERSION}
+  else
+    # Retrieve latest version
+    echo "➡️ Retrieving latest version"
+    VERSION=$(curl --silent "https://api.github.com/repos/Keeper-Security/secrets-manager/releases/latest" | grep tag_name | awk -F\" '{ print $4 }' | awk -F- '{print $3}')
+  fi
+
+  # Exit if version is already installed
+  if command -v ksm >/dev/null 2>&1 && ksm version 2>&1 | grep "CLI Version: " | cut -d " " -f 3 | grep -q "${VERSION}$"; then
+    echo "➡️ Version ${VERSION} is already installed"
+    exit 0
+  fi
+
+  echo "➡️ Downloading version ${VERSION}"
+  ARCHIVE_NAME=keeper-secrets-manager-cli-$OS-$VERSION
+  LINK_TAR=https://github.com/Keeper-Security/secrets-manager/releases/download/ksm-cli-$VERSION/$ARCHIVE_NAME.tar.gz
+
+  curl -fsSL "${LINK_TAR}" | $SUDO tar -xz -C /usr/local/ksm;
+
+  # symlink in the PATH
+  $SUDO ln -sf /usr/local/ksm/ksm /usr/local/bin/ksm
+}
+
+InstallKsm() {
+  is_alpine=$(isAlpine)
+
+  if [ "$is_alpine" = "true" ]; then
+    installKsmAlpine
+  else
+    installKsmWithBinary
+  fi
+}
+
+if [ "${0#*$TEST_ENV}" = "$0" ]; then
+    InstallKsm
 fi
-
-# Make sure we have root priviliges.
-SUDO=""
-if [ "$(id -u)" -ne 0 ]; then
-    if ! [ "$(command -v sudo)" ]; then
-        echo "${ERROR_COLOR}Installer requires root privileges. Please run this script as root.${NO_COLOR}"
-        exit;
-    fi
-    SUDO="sudo"
-fi
-
-echo "${OK_COLOR}==> Creating directories${NO_COLOR}"
-$SUDO mkdir -p /usr/local/ksm/bin
-
-if [ "${KSM_CLI_VERSION:-latest}" != "latest" ]; then
-  VERSION=${KSM_CLI_VERSION}
-else
-  # Retrieve latest version
-  echo "${OK_COLOR}==> Retrieving latest version${NO_COLOR}"
-  VERSION=$(curl --silent "https://api.github.com/repos/Keeper-Security/secrets-manager/releases/latest" | grep tag_name | awk -F\" '{ print $4 }' | awk -F- '{print $3}')
-fi
-
-# Exit if version is already installed
-if command -v ksm >/dev/null 2>&1 && ksm version 2>&1 | grep "CLI Version: " | cut -d " " -f 3 | grep -q "${VERSION}$"; then
-  echo "${OK_COLOR}==> Version ${VERSION} is already installed${NO_COLOR}"
-  exit 0
-fi
-
-echo "${OK_COLOR}==> Downloading version ${VERSION}${NO_COLOR}"
-ARCHIVE_NAME=keeper-secrets-manager-cli-$OS-$VERSION
-LINK_TAR=https://github.com/Keeper-Security/secrets-manager/releases/download/ksm-cli-$VERSION/$ARCHIVE_NAME.tar.gz
-
-curl -fsSL "${LINK_TAR}" | $SUDO tar -xz -C /usr/local/ksm;
-
-# symlink in the PATH
-$SUDO ln -sf /usr/local/ksm/ksm /usr/local/bin/ksm

--- a/src/scripts/install/install_ksm_tests.bats
+++ b/src/scripts/install/install_ksm_tests.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_ENV="bats-core"
+
+  source ./src/scripts/install/install_ksm.sh
+
+  installKsmAlpine() {
+    echo "installKsmAlpine"
+  }
+
+  installKsmWithBinary() {
+    echo "installKsmWithBinary"
+  }
+}
+
+teardown() {
+    rm -f /tmp/bashenv
+    rm -f /tmp/keeper.ini
+}
+
+@test "InstallKsm should install KSM for Alpine when running on Alpine Linux" {
+  readOsReleaseFile() {
+    echo "ID=alpine"
+  }
+
+  result=$(InstallKsm)
+  [ "$result" == "installKsmAlpine" ]
+}
+
+@test "InstallKsm should install KSM with binary when not running on Alpine Linux" {
+  readOsReleaseFile() {
+    echo "ID=other"
+  }
+
+  result=$(InstallKsm)
+  [ "$result" == "installKsmWithBinary" ]
+}
+
+@test "InstallKsm should install KSM with binary when /etc/os-release file does not exist" {
+  readOsReleaseFile() {
+    echo ""
+  }
+
+  result=$(InstallKsm)
+  [ "$result" == "installKsmWithBinary" ]
+}


### PR DESCRIPTION
Update the `install_ksm` script to install KSM with PIP when run on Alpine-based systems.

I've also changed the shebang to sh and all bash-related code because bash can not be installed.
It should support more systems.