### PR TITLE
feat: add exec command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -113,6 +113,27 @@ jobs:
               exit 1;
             fi
 
+  integration-test-exec:
+    docker:
+      - image: cimg/base:stable
+    environment:
+      MY_USER: keeper://zB_JnULMlYaeCEQPE8p3HA/field/login
+      MY_PASSWORD: keeper://zB_JnULMlYaeCEQPE8p3HA/field/password
+    steps:
+      - keeper/exec:
+          step-name: "Assert secret has been loaded"
+          command: |
+            if [ "$MY_USER" != "test" ]; then
+              echo "❌ MY_USER env invalid"
+              echo "Expected MY_USER=test, but was MY_USER=${MY_USER}"
+              exit 1;
+            fi              
+            if [ "$MY_PASSWORD" != "keeper2022" ]; then
+              echo "❌ MY_PASSWORD env invalid"
+              echo "Expected MY_PASSWORD=keeper2022, but was MY_PASSWORD=${MY_PASSWORD}"
+              exit 1;
+            fi
+
 workflows:
   test-deploy:
     jobs:
@@ -127,6 +148,8 @@ workflows:
           filters: *filters
       - integration-test-env-export-on-alpine:
           filters: *filters
+      - integration-test-exec:
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -140,6 +163,7 @@ workflows:
             - integration-test-install-on-alpine
             - integration-test-env-export
             - integration-test-env-export-on-alpine
+            - integration-test-exec
           context: keeper-orb-publishing
           filters:
             branches:

--- a/src/commands/exec.yml
+++ b/src/commands/exec.yml
@@ -1,0 +1,22 @@
+description: Run a command with secret environment variables loaded from Keeper
+parameters:
+  command:
+    type: string
+    description: Command to execute with secrets
+  step-name:
+    type: string
+    default: ''
+    description: Title of the step to show in the CircleCI UI
+  flags:
+    type: string
+    default: ''
+    description: Flags to pass to the `ksm exec` command
+
+steps:
+  - install
+  - run:
+      name: << parameters.step-name >>
+      environment:
+        FLAGS: << parameters.flags >>
+        COMMAND: << parameters.command >>
+      command: <<include(scripts/exec/exec.sh)>>

--- a/src/examples/env_export_command.yml
+++ b/src/examples/env_export_command.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    secrethub: gravitee-io/keeper@x.y.z
+    keeper: gravitee-io/keeper@x.y.z
     docker: circleci/docker@x.y.z
 
   workflows:

--- a/src/examples/exec_command_with_secrets.yml
+++ b/src/examples/exec_command_with_secrets.yml
@@ -1,0 +1,28 @@
+description: >
+  Use the keeper/exec command to automatically install the Keeper Secrets Manager CLI, load secrets on demand and
+  execute a command that needs the secrets.
+
+usage:
+  version: 2.1
+
+  orbs:
+    keeper: gravitee-io/keeper@x.y.z
+
+  jobs:
+    deploy:
+      docker:
+        - image: cimg/base:stable
+      environment:
+        MY_USER: keeper://zB_JnULMlYaeCEQPE8p3HA/field/login
+        MY_PASSWORD: keeper://zB_JnULMlYaeCEQPE8p3HA/field/password
+      steps:
+        - keeper/exec:
+            step-name: "Docker login and push"
+            command: |
+              echo $MY_PASSWORD | docker login --username $MY_USER --password-stdin
+              docker push myimage
+
+  workflows:
+    publish:
+      jobs:
+        - deploy

--- a/src/scripts/exec/exec.sh
+++ b/src/scripts/exec/exec.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+Exec() {
+   if [ -z "${COMMAND:-}" ]; then
+     >&2 echo "COMMAND env var not set. Nothing to execute"
+     exit 1
+   fi
+
+   cat <<EOF > /tmp/ksm_exec.sh
+#!$SHELL
+$COMMAND
+EOF
+
+  chmod 755 /tmp/ksm_exec.sh
+
+  KsmExec
+}
+
+KsmExec() {
+  ksm exec -- /tmp/ksm_exec.sh
+}
+
+
+# Will not run if sourced from another script.
+# This is done so this script may be tested.
+if [ "${0#*$TEST_ENV}" = "$0" ]; then
+    Exec
+fi

--- a/src/scripts/exec/exec_tests.bats
+++ b/src/scripts/exec/exec_tests.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_ENV="bats-core"
+  export BASH_ENV=/tmp/bashenv
+  export SHELL=/bin/sh
+  export COMMAND="echo \"secret: \$MY_USER\""
+
+  source ./src/scripts/exec/exec.sh
+
+  KsmExec() {
+    return 0
+  }
+}
+
+teardown() {
+    rm -f /tmp/ksm_exec.sh
+}
+
+@test "Exec should create a temporary file containing the command to execute" {
+  run Exec
+  [ "$status" -eq 0 ]
+
+  if [[ ! -f "/tmp/ksm_exec.sh" ]]; then
+    echo "/tmp/ksm_exec.sh does not exist."
+    exit 1;
+  fi
+
+  expected=$(
+    cat << EOF
+#!/bin/sh
+echo "secret: \$MY_USER"
+EOF
+)
+  result=$(cat /tmp/ksm_exec.sh)
+
+  [ "$result" == "$expected" ]
+}
+
+@test "Exec should fail when COMMAND not set" {
+  unset COMMAND
+
+  run Exec
+  [ "$status" -eq 1 ]
+  [ "$output" = "COMMAND env var not set. Nothing to execute" ]
+}


### PR DESCRIPTION
keeper/exec command will create a temporary scrip file containing the command to execute.
Then, it will run this script using `ksm exec`.

~Two workarounds are necessary:~
- ~we need to provide `--capture-output`: https://github.com/Keeper-Security/secrets-manager/pull/244~
- ~we unset CIRCLE_PROJECT_REPONAME env var: https://github.com/Keeper-Security/secrets-manager/issues/243#issuecomment-1079700528~