### PR TITLE
fix: execute env-export command in /tmp

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -84,6 +84,13 @@ jobs:
               echo "Content of export command: $(cat $BASH_ENV)"
               exit 1;
             fi
+      - run:
+          name: "Assert no keeper.ini created"
+          command: |
+            if [[ -f keeper.ini ]]; then
+              echo "❌ keeper.ini file created in the current directory."
+              exit 1
+            fi
 
   integration-test-env-export-on-alpine:
     docker:

--- a/src/commands/env-export.yml
+++ b/src/commands/env-export.yml
@@ -18,5 +18,5 @@ steps:
       environment:
         SECRET_ENV_NAME: << parameters.var-name >>
         SECRET_URL: << parameters.secret-url >>
-
+      working_directory: /tmp
       command: <<include(scripts/env-export/env-export.sh)>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -26,9 +26,11 @@ steps:
       environment:
         KSM_CLI_VERSION: << parameters.version >>
       command: <<include(scripts/install/install_ksm.sh)>>
+      working_directory: /tmp
   - run:
       name: "Initialize Keeper config"
       shell: << parameters.shell >>
       environment:
         KEEPER_INI_DIR: << parameters.ini_dir >>
       command: <<include(scripts/install/init_config.sh)>>
+      working_directory: /tmp


### PR DESCRIPTION
Change the `working_directory` to prevent creating a `keeper.ini` file. 
See https://github.com/Keeper-Security/secrets-manager/issues/246

I didn't update the `exec` command as the script could not expect to be run in `/tmp`