### PR TITLE
fix: install command use fixed version as default

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - keeper/install:
           version: 1.0.7
       - run:
-          name: "Assert keeper installation"
+          name: "Assert no keeper.ini created"
           command: |
             if [[ -f keeper.ini ]]; then
               echo "❌ keeper.ini file created in the current directory."
@@ -39,6 +39,17 @@ jobs:
             fi      
             if [[ ! -f /tmp/keeper.ini ]]; then
               echo "❌ no keeper.ini file created in the /tmp directory."
+              exit 1
+            fi
+      - run:
+          name: "Assert keeper version installed"
+          working_directory: /tmp
+          command: |
+            export INSTALLED=$(ksm version | grep "CLI Version" | awk -F": " '{ print $2 }')
+
+            if [[ "$INSTALLED" != "1.0.7" ]]; then
+              echo "❌ Incorrect installed version. "
+              echo "Expected 1.0.7, but was ${INSTALLED}"
               exit 1
             fi
 

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,8 +4,8 @@ description: >
 parameters:
   version:
     type: string
-    default: "latest"
-    description: "Version of the KSM CLI"
+    default: "1.0.9"
+    description: "Version of the KSM CLI. Use latest to fetch the latest version."
   path:
     type: string
     default: /usr/local/bin

--- a/src/examples/install_latest_version.yml
+++ b/src/examples/install_latest_version.yml
@@ -1,0 +1,22 @@
+description: >
+  Install a specific version of Keeper Secrets Manager CLI.
+usage:
+  version: 2.1
+
+  orbs:
+    keeper: gravitee-io/keeper@x.y.z
+
+  jobs:
+    deploy:
+      docker:
+        - image: cimg/base:stable
+      steps:
+        - checkout
+        - keeper/install:
+            version: latest
+        - run: ksm version
+
+  workflows:
+    deploy:
+      jobs:
+        - deploy

--- a/src/examples/install_specific_version.yml
+++ b/src/examples/install_specific_version.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
 
   orbs:
-    keeper: jgiovaresco/keeper@x.y.z
+    keeper: gravitee-io/keeper@x.y.z
 
   jobs:
     deploy:


### PR DESCRIPTION
The script fetching the latest version from GitHub can be flaky.
To prevent to much call, we install a fixed version by default.