### PR TITLE
ci: adding devops as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*             @gravitee-io/techops @jgiovaresco
+*             @gravitee-io/devops


### PR DESCRIPTION
this PR is created in order to add the devops team as codeowner