### PR TITLE
fix: azurelinux image compatibility + get release of ksm-cli only

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -131,6 +131,34 @@ jobs:
               exit 1;
             fi
 
+  integration-test-env-export-on-azurelinux:
+    docker:
+      - image: mcr.microsoft.com/azure-cli:latest
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://hNWDMrAXND1mlwmBgGvIpg/field/login
+          var-name: MY_USER
+      - keeper/env-export:
+          secret-url: keeper://hNWDMrAXND1mlwmBgGvIpg/field/password
+          var-name: MY_PASSWORD
+      - run:
+          name: "Assert environment variables set"
+          command: |
+            . $BASH_ENV
+            
+            if [[ "$MY_USER" != "test" ]]; then
+              echo "❌ MY_USER env invalid"
+              echo "Expected MY_USER=test, but was MY_USER=${MY_USER}"
+              echo "Content of export command: $(cat $BASH_ENV)"
+              exit 1;
+            fi              
+            if [[ "$MY_PASSWORD" != ")8y9jh8{9siN^;HnL,km" ]]; then
+              echo "❌ MY_PASSWORD env invalid"
+              echo "Expected MY_PASSWORD=)8y9jh8{9siN^;HnL,km, but was MY_PASSWORD=${MY_USER}"
+              echo "Content of export command: $(cat $BASH_ENV)"
+              exit 1;
+            fi
+
   integration-test-exec:
     docker:
       - image: cimg/base:stable
@@ -166,6 +194,8 @@ workflows:
           filters: *filters
       - integration-test-env-export-on-alpine:
           filters: *filters
+      - integration-test-env-export-on-azurelinux:
+          filters: *filters
       - integration-test-exec:
           filters: *filters
       - orb-tools/pack:
@@ -181,6 +211,7 @@ workflows:
             - integration-test-install-on-alpine
             - integration-test-env-export
             - integration-test-env-export-on-alpine
+            - integration-test-env-export-on-azurelinux
             - integration-test-exec
           context: keeper-orb-publishing
           filters:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Currently, the orb contains the following commands:
 - `install`: to install [Keeper Secrets Manager CLI](https://docs.keeper.io/secrets-manager/secrets-manager/secrets-manager-command-line-interface)
 - `env-export`: to export a secret value in an environment variable automatically
-- `exec`: to run run a command with secret environment variables loaded from Keeper
+- `exec`: to run a command with secret environment variables loaded from Keeper
 
 **Meta**: This repository is open for contributions! Feel free to open a pull request with your changes.
 

--- a/src/scripts/install/init_config.sh
+++ b/src/scripts/install/init_config.sh
@@ -11,6 +11,17 @@ InitKeeperConfig() {
     exit 1
   fi
 
+  if grep '^ID=' /etc/*release* | grep -q -i azurelinux
+  then
+    cat >> "$BASH_ENV" <<EOF
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+EOF
+    # export it right now to also let ksm_init_config pass
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+  fi
+
   echo "KSM_INI_DIR=${KEEPER_INI_DIR}" >> "$BASH_ENV"
 
   cd /tmp


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

* This add compatibility with azurelinux docker image and install
  prerequisite.
* Also because the Keeper-Security/secrets-manager project include
  multiple product on same repo, and then multiple release. We have to
  filter the release to get only ksm-cli ones.

## Motivation:

Make this compatible with Azurelinux image.

 **Closes Issues:**
-  https://gravitee.atlassian.net/browse/TT-6649

## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.

