### PR TITLE
feat: prevent requiring root privilege to install ksm

### DIFF
--- a/src/commands/env-export.yml
+++ b/src/commands/env-export.yml
@@ -10,12 +10,17 @@ parameters:
     description: >
       Secret notation "url". Ex: keeper://RECORD_UID/field/password
       See: https://docs.keeper.io/secrets-manager/secrets-manager/secrets-manager-command-line-interface/secret-command#notation
+  install-dir:
+    type: string
+    default: /tmp/keeper
+    description: "Path where KSM CLI is installed"
 
 steps:
   - install
   - run:
       name: Load secret in << parameters.var-name >>
       environment:
+        KSM_INSTALL_DIR: << parameters.install-dir >>
         SECRET_ENV_NAME: << parameters.var-name >>
         SECRET_URL: << parameters.secret-url >>
       working_directory: /tmp

--- a/src/commands/exec.yml
+++ b/src/commands/exec.yml
@@ -11,12 +11,17 @@ parameters:
     type: string
     default: ''
     description: Flags to pass to the `ksm exec` command
+  install-dir:
+    type: string
+    default: /tmp/keeper
+    description: "Path where KSM CLI is installed"
 
 steps:
   - install
   - run:
       name: << parameters.step-name >>
       environment:
+        KSM_INSTALL_DIR: << parameters.install-dir >>
         FLAGS: << parameters.flags >>
         COMMAND: << parameters.command >>
       command: <<include(scripts/exec/exec.sh)>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -8,7 +8,7 @@ parameters:
     description: "Version of the KSM CLI. Use latest to fetch the latest version."
   path:
     type: string
-    default: /usr/local/bin
+    default: /tmp/keeper
     description: "Path to install KSM CLI to"
   shell:
     type: string
@@ -24,6 +24,7 @@ steps:
       name: "Ensure KSM CLI is installed"
       shell: << parameters.shell >>
       environment:
+        KSM_INSTALL_DIR: << parameters.path >>
         KSM_CLI_VERSION: << parameters.version >>
       command: <<include(scripts/install/install_ksm.sh)>>
       working_directory: /tmp
@@ -31,6 +32,7 @@ steps:
       name: "Initialize Keeper config"
       shell: << parameters.shell >>
       environment:
+        KSM_INSTALL_DIR: << parameters.path >>
         KEEPER_INI_DIR: << parameters.ini_dir >>
       command: <<include(scripts/install/init_config.sh)>>
       working_directory: /tmp

--- a/src/scripts/env-export/env-export.sh
+++ b/src/scripts/env-export/env-export.sh
@@ -7,7 +7,7 @@ generate_random_heredoc_identifier() {
 
 get_secret_from_ksm() {
   url=$1
-  ksm secret notation "${url}"
+  "${KSM_INSTALL_DIR}/ksm" secret notation "${url}"
 }
 
 EnvExport() {

--- a/src/scripts/env-export/env-export_tests.bats
+++ b/src/scripts/env-export/env-export_tests.bats
@@ -3,6 +3,7 @@
 setup() {
   export TEST_ENV="bats-core"
   export BASH_ENV=/tmp/bashenv
+  export INSTALL_DIR=/tmp/keeper
   export SECRET_ENV_NAME=MY_ENV
   export SECRET_URL=my_secret_url
 

--- a/src/scripts/exec/exec.sh
+++ b/src/scripts/exec/exec.sh
@@ -18,7 +18,7 @@ EOF
 }
 
 KsmExec() {
-  ksm exec -- /tmp/ksm_exec.sh
+  "${KSM_INSTALL_DIR}/ksm" exec -- /tmp/ksm_exec.sh
 }
 
 

--- a/src/scripts/install/init_config.sh
+++ b/src/scripts/install/init_config.sh
@@ -2,7 +2,7 @@
 set -e
 
 ksm_init_config(){
-  ksm version
+  "${KSM_INSTALL_DIR}/ksm" version
 }
 
 InitKeeperConfig() {

--- a/src/scripts/install/install_ksm_tests.bats
+++ b/src/scripts/install/install_ksm_tests.bats
@@ -22,7 +22,7 @@ setup() {
   }
 
   fetchBinary() {
-    echo "fetch $2"
+    echo "fetch $1"
   }
 }
 


### PR DESCRIPTION
This PR applies some changes to prevent the root privileges required to install the KSM CLI tool.
In some Docker images we used as CircleCI executor, we can't use `sudo` (ex: the latest `sonarsource/sonar-scanner-cli` images); therefore, we couldn't fetch secrets from KSM.