### PR TITLE
fix: bump default KSM CLI version to 1.3.0

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -18,9 +18,11 @@ jobs:
             if [[ -f keeper.ini ]]; then
               echo "❌ keeper.ini file created in the current directory."
               exit 1
-            fi      
-            if [[ ! -f /tmp/keeper.ini ]]; then
-              echo "❌ no keeper.ini file created in the /tmp directory."
+            fi
+            # Newer KSM CLI versions use the config from KSM_CONFIG in-memory and
+            # no keeper.ini is persisted anymore: assert the CLI works instead.
+            if ! /tmp/keeper/ksm version | grep "CLI Version: "; then
+              echo "❌ ksm CLI not installed or not working."
               exit 1
             fi
 
@@ -64,9 +66,11 @@ jobs:
             if [[ -f keeper.ini ]]; then
               echo "❌ keeper.ini file created in the current directory."
               exit 1
-            fi      
-            if [[ ! -f /tmp/keeper.ini ]]; then
-              echo "❌ no keeper.ini file created in the /tmp directory."
+            fi
+            # Newer KSM CLI versions use the config from KSM_CONFIG in-memory and
+            # no keeper.ini is persisted anymore: assert the CLI works instead.
+            if ! /tmp/keeper/ksm version | grep "CLI Version: "; then
+              echo "❌ ksm CLI not installed or not working."
               exit 1
             fi
 

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   version:
     type: string
-    default: "1.0.9"
+    default: "1.3.0"
     description: "Version of the KSM CLI. Use latest to fetch the latest version."
   path:
     type: string


### PR DESCRIPTION
## Description

Bump the default KSM CLI version from 1.0.9 (2022) to **1.3.0**.

On 2026-07-08, the Keeper backend temporarily rejected old clients (`Error: invalid client version id: 2317, mp16.2.0`), breaking every job using `keeper/env-export` / `keeper/exec` org-wide. The enforcement was rolled back a few hours later, but it will likely come back — this PR gets ahead of it.

- 1.3.0 ships an SDK (`keeper-secrets-manager-core >= 17.2.0`) accepted by the backend, and keeps the tarball layout expected by `install_ksm.sh` — no script change needed. 1.4.0 changed the packaging (multi-binary + interactive `install.sh`) and is left as a follow-up.
- Integration test assertions adapted: recent CLI versions no longer persist a `keeper.ini`, so the tests assert the installed CLI works instead.

Once released, consuming repos need to bump their `gravitee-io/keeper@x.y.z` reference (Renovate covers repos where it's enabled; support branches need a manual bump).
